### PR TITLE
Add --no-tty Option

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 server: php artisan serve --host=0.0.0.0 --no-reload
 tail: php artisan pail --timeout=0
 queue: php artisan queue:listen --tries=1
-tailwind: php artisan tailwindcss:watch
+tailwind: php artisan tailwindcss:watch --no-tty

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
             "@php artisan key:generate --ansi",
             "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
             "@php artisan tailwindcss:download --force",
-            "@php artisan tailwindcss:build",
+            "@php artisan tailwindcss:build --no-tty",
             "@php artisan storage:link",
             "@php artisan migrate --graceful --ansi"
         ],


### PR DESCRIPTION
Hi Tony.

I have problem after download and develop the starter kit in macOS arm64. The exact problem is in TailwindCSS that the current CLI build with Bun and make experince of `tailwindcss:watch` interuptted if I don't put the `--no-tty` option (link: https://github.com/tailwindlabs/tailwindcss/issues/16344). I saw the Bun version in TailwindCSS CLI is v1.1.43 meanwhile the Bun version right now is v1.3.3. I'm not sure that if the TailwindCSS use the latest version of Bun will solve the problem. But, for the short term, I think it's better if we put the `--no-tty` option by default in `composer.json` and `Procfile`. This is win to win solution for both users especially who use the macOS arm64 that want to try the experience of Hotwire Laravel. If I run `composer run dev:overmind` without the `--no-tty` in artisan command `tailwindcss:watch` then the server will be exited.

```sh
❯ composer run dev:overmind
> Composer\Config::disableProcessTimeout
> overmind start
system   | Tmux socket name: overmind-turbo-chirper-cVlyc5u5bGs8enkY4AWvf
system   | Tmux session ID: turbo-chirper
system   | Listening at ./.overmind.sock
tailwind | Started with pid 36908...
tail     | Started with pid 36906...
server   | Started with pid 36905...
queue    | Started with pid 36907...
tailwind | Building assets...
queue    | 
queue    |    INFO  Processing jobs from the [default] queue.  
queue    | 
tail     | 
tail     |    INFO  Tailing application logs.             Press Ctrl+C to exit  
tail     |                                     Use -v|-vv to show more details  
tailwind | /*! 🌼 daisyUI 5.0.8 */
tailwind | error: Invalid argument
tailwind |  syscall: "kqueue",
tailwind |    errno: -22,
tailwind |     code: "EINVAL",
tailwind | 
tailwind |       at pull (unknown:1:1)
tailwind |       at createResult2 (native:25:32)
tailwind |       at #pull (native:77:12)
tailwind |       at native:1:1
tailwind |       at native:1:1
tailwind |       at native:1:1
tailwind |       at native:8:161
tailwind |       at processTicksAndRejections (native:7:39)
tailwind | 
tailwind | Bun v1.1.43 (macOS arm64)
tailwind | Done!
tailwind | Exited with code 0
server   | 
server   |    INFO  Server running on [http://0.0.0.0:8000].  
server   | 
server   |   Press Ctrl+C to stop the server
server   | 
server   | Interrupting...
tail     | Interrupting...
queue    | Interrupting...
tail     | 
tail     | Exited with code 0
server   | Exited with code 0
queue    | Exited with code 0
```